### PR TITLE
minor date issue in the example.

### DIFF
--- a/src/component/counter/counter.js
+++ b/src/component/counter/counter.js
@@ -11,7 +11,7 @@ class Counter extends Nerv.Component {
     const date = new Date()
     const year = date.getFullYear()
     const month = date.getMonth() + 1
-    const day = date.getDay()
+    const day = date.getDate()
     const hour = date.getHours()
     const minute = date.getMinutes()
     const sec = date.getSeconds()


### PR DESCRIPTION
getDay returns 0-6 depending on the day of the week.
getDate however returns the date you want (0-31).